### PR TITLE
Implement Basic Single-Threaded TCP Server

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="25" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/multithreaded-web-server.iml" filepath="$PROJECT_DIR$/.idea/multithreaded-web-server.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/multithreaded-web-server.iml
+++ b/.idea/multithreaded-web-server.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Server.java
+++ b/Server.java
@@ -1,0 +1,30 @@
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class Server {
+    public static void main(String[] args) {
+        int port = 8010;
+
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            System.out.println("Server is listening on port " + port);
+
+            while (true) {
+                // This call blocks until a client connects.
+                Socket clientSocket = serverSocket.accept();
+                System.out.println("Client connected: " + clientSocket.getInetAddress());
+
+                // Handle the client connection directly on the main thread.
+                try (PrintWriter toSocket = new PrintWriter(clientSocket.getOutputStream(), true)) {
+                    toSocket.println("Hello from the single-threaded server!");
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                // The try-with-resources automatically closes the clientSocket here.
+            }
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Title: feat: add basic single-threaded TCP server (Server.java)

Motivation: “To create a simple educational foundation for a TCP server, capable of handling one client at a time.”

Summary: “Added Server.java which listens on port 8010 and responds to a single client connection. This sets the base for later multithreading improvements.”

Additional Notes: “Tested by connecting a single client via telnet localhost 8010. Server prints connected client info.”